### PR TITLE
atualizacao de dependencias do illuminate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "laravel/framework": "5.* || ^6.0",
-        "illuminate/support": "5.* || ^5"
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
+        "illuminate/validation": "^5.0|^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Removendo dependencia de laravel/framework, ao inves disto somente dos
  fragmentos necessarios do framework foram marcados como dependencia,
  bem como as versoes em que esta lib podera ser instalada;